### PR TITLE
DSO-971: adding connections_open label

### DIFF
--- a/cmd/tusd/cli/metrics.go
+++ b/cmd/tusd/cli/metrics.go
@@ -1,20 +1,21 @@
 package cli
 
 import (
-	"net/http"
-
 	"github.com/tus/tusd/v2/pkg/handler"
 	"github.com/tus/tusd/v2/pkg/hooks"
 	"github.com/tus/tusd/v2/pkg/prometheuscollector"
+	"net/http"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
-var MetricsOpenConnections = prometheus.NewGauge(prometheus.GaugeOpts{
+var MetricsOpenConnections = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 	Name: "tusd_connections_open",
-	Help: "Current number of open connections.",
-})
+	Help: "Current number of open connections.",},
+	[]string{"computername"},
+	
+)
 
 func SetupMetrics(mux *http.ServeMux, handler *handler.Handler) {
 	prometheus.MustRegister(MetricsOpenConnections)

--- a/cmd/tusd/cli/serve.go
+++ b/cmd/tusd/cli/serve.go
@@ -11,7 +11,7 @@ import (
 	"regexp"
 	"strings"
 	"syscall"
-
+	"github.com/prometheus/client_golang/prometheus"
 	tushandler "github.com/tus/tusd/v2/pkg/handler"
 	"github.com/tus/tusd/v2/pkg/hooks"
 	"github.com/tus/tusd/v2/pkg/hooks/plugin"
@@ -146,9 +146,9 @@ func Serve() {
 		ConnState: func(_ net.Conn, cs http.ConnState) {
 			switch cs {
 			case http.StateNew:
-				MetricsOpenConnections.Inc()
+				MetricsOpenConnections.With(prometheus.Labels{"computername": os.Getenv("COMPUTERNAME")}).Inc()
 			case http.StateClosed, http.StateHijacked:
-				MetricsOpenConnections.Dec()
+				MetricsOpenConnections.With(prometheus.Labels{"computername": os.Getenv("COMPUTERNAME")}).Dec()
 			}
 		},
 		BaseContext: func(_ net.Listener) context.Context {

--- a/pkg/handler/doc.go
+++ b/pkg/handler/doc.go
@@ -7,7 +7,7 @@ re-uploading the previous data again. An interruption may happen willingly, if
 the user wants to pause, or by accident in case of an network issue or server
 outage (http://tus.io).
 
-The basics of tusd
+# The basics of tusd
 
 tusd was designed in way which allows an flexible and customizable usage. We
 wanted to avoid binding this package to a specific storage system – particularly
@@ -22,7 +22,7 @@ current state. Therefore it is the only part of the system which communicates
 directly with the underlying storage system, whether it be the local disk, a
 remote FTP server or cloud providers such as AWS S3.
 
-Using a store composer
+# Using a store composer
 
 The only hard requirements for a data store can be found in the DataStore
 interface. It contains methods for creating uploads (NewUpload), writing to
@@ -35,10 +35,10 @@ TerminaterDataStore which allows uploads to be terminated.
 The store composer offers a way to combine the basic data store - the core -
 implementation and these additional extensions:
 
-  composer := tusd.NewStoreComposer()
-  composer.UseCore(dataStore) // Implements DataStore
-  composer.UseTerminater(terminater) // Implements TerminaterDataStore
-  composer.UseLocker(locker) // Implements LockerDataStore
+	composer := tusd.NewStoreComposer()
+	composer.UseCore(dataStore) // Implements DataStore
+	composer.UseTerminater(terminater) // Implements TerminaterDataStore
+	composer.UseLocker(locker) // Implements LockerDataStore
 
 The corresponding methods for adding an extension to the composer are prefixed
 with Use* followed by the name of the corresponding interface. However, most
@@ -47,23 +47,23 @@ tedious and error-prone. Therefore, all data store distributed with tusd provide
 an UseIn() method which does this job automatically. For example, this is the
 S3 store in action (see S3Store.UseIn):
 
-  store := s3store.New(…)
-  locker := memorylocker.New()
-  composer := tusd.NewStoreComposer()
-  store.UseIn(composer)
-  locker.UseIn(composer)
+	store := s3store.New(…)
+	locker := memorylocker.New()
+	composer := tusd.NewStoreComposer()
+	store.UseIn(composer)
+	locker.UseIn(composer)
 
 Finally, once you are done with composing your data store, you can pass it
 inside the Config struct in order to create create a new tusd HTTP handler:
 
-  config := tusd.Config{
-    StoreComposer: composer,
-    BasePath: "/files/",
-  }
-  handler, err := tusd.NewHandler(config)
+	config := tusd.Config{
+	  StoreComposer: composer,
+	  BasePath: "/files/",
+	}
+	handler, err := tusd.NewHandler(config)
 
 This handler can then be mounted to a specific path, e.g. /files:
 
-  http.Handle("/files/", http.StripPrefix("/files/", handler))
+	http.Handle("/files/", http.StripPrefix("/files/", handler))
 */
 package handler

--- a/pkg/hooks/hooks.go
+++ b/pkg/hooks/hooks.go
@@ -149,7 +149,7 @@ var MetricsHookErrorsTotal = prometheus.NewCounterVec(
 		Name: "tusd_hook_errors_total",
 		Help: "Total number of execution errors per hook type.",
 	},
-	[]string{"hooktype","computername"},
+	[]string{"hooktype", "computername"},
 )
 
 var MetricsHookInvocationsTotal = prometheus.NewCounterVec(
@@ -157,24 +157,24 @@ var MetricsHookInvocationsTotal = prometheus.NewCounterVec(
 		Name: "tusd_hook_invocations_total",
 		Help: "Total number of invocations per hook type.",
 	},
-	[]string{"hooktype","computername"},
+	[]string{"hooktype", "computername"},
 )
 
 func SetupHookMetrics() {
 
 	computerName := os.Getenv("COMPUTERNAME")
-	MetricsHookErrorsTotal.WithLabelValues(string(HookPostFinish),computerName).Add(0)
-	MetricsHookErrorsTotal.WithLabelValues(string(HookPostTerminate),computerName).Add(0)
-	MetricsHookErrorsTotal.WithLabelValues(string(HookPostReceive),computerName).Add(0)
-	MetricsHookErrorsTotal.WithLabelValues(string(HookPostCreate),computerName).Add(0)
-	MetricsHookErrorsTotal.WithLabelValues(string(HookPreCreate),computerName).Add(0)
-	MetricsHookErrorsTotal.WithLabelValues(string(HookPreFinish),computerName).Add(0)
-	MetricsHookInvocationsTotal.WithLabelValues(string(HookPostFinish),computerName).Add(0)
-	MetricsHookInvocationsTotal.WithLabelValues(string(HookPostTerminate),computerName).Add(0)
-	MetricsHookInvocationsTotal.WithLabelValues(string(HookPostReceive),computerName).Add(0)
-	MetricsHookInvocationsTotal.WithLabelValues(string(HookPostCreate),computerName).Add(0)
-	MetricsHookInvocationsTotal.WithLabelValues(string(HookPreCreate),computerName).Add(0)
-	MetricsHookInvocationsTotal.WithLabelValues(string(HookPreFinish),computerName).Add(0)
+	MetricsHookErrorsTotal.WithLabelValues(string(HookPostFinish), computerName).Add(0)
+	MetricsHookErrorsTotal.WithLabelValues(string(HookPostTerminate), computerName).Add(0)
+	MetricsHookErrorsTotal.WithLabelValues(string(HookPostReceive), computerName).Add(0)
+	MetricsHookErrorsTotal.WithLabelValues(string(HookPostCreate), computerName).Add(0)
+	MetricsHookErrorsTotal.WithLabelValues(string(HookPreCreate), computerName).Add(0)
+	MetricsHookErrorsTotal.WithLabelValues(string(HookPreFinish), computerName).Add(0)
+	MetricsHookInvocationsTotal.WithLabelValues(string(HookPostFinish), computerName).Add(0)
+	MetricsHookInvocationsTotal.WithLabelValues(string(HookPostTerminate), computerName).Add(0)
+	MetricsHookInvocationsTotal.WithLabelValues(string(HookPostReceive), computerName).Add(0)
+	MetricsHookInvocationsTotal.WithLabelValues(string(HookPostCreate), computerName).Add(0)
+	MetricsHookInvocationsTotal.WithLabelValues(string(HookPreCreate), computerName).Add(0)
+	MetricsHookInvocationsTotal.WithLabelValues(string(HookPreFinish), computerName).Add(0)
 }
 
 func invokeHookAsync(typ HookType, event handler.HookEvent, hookHandler HookHandler) {


### PR DESCRIPTION
Additions

- cmd/tusd/cli/metrics.go: changing connections_open to GaugeVec metric, to add computername label
- cmd/tusd/cli/serve.go: adding computername label to connectionsOpen


the rest is stuff `go fmt` dragged in